### PR TITLE
Rashid/review curd

### DIFF
--- a/src/app/modules/Review/review.controller.ts
+++ b/src/app/modules/Review/review.controller.ts
@@ -12,6 +12,55 @@ const createReview = catchAsyncResponse(async (req, res) => {
     data: result,
   });
 });
+
+const updateReview = catchAsyncResponse(async (req, res) => {
+  const userId = req.query.userId;
+  const reviewId = req.query.reviewId;
+  if (!userId || !reviewId) {
+    return manageResponse(res, {
+      statusCode: status.BAD_REQUEST,
+      success: false,
+      message: 'User ID and Review ID are required',
+    });
+  }
+  const result = await reviewService.updateReview(
+    req.body,
+    reviewId as string,
+    userId as string,
+  );
+  manageResponse(res, {
+    statusCode: status.CREATED,
+    success: true,
+    message: 'Review Updated successfully',
+    data: result,
+  });
+});
+const deleteReview = catchAsyncResponse(async (req, res) => {
+  const userId = req.query.userId;
+  const reviewId = req.query.reviewId;
+
+  if (!userId || !reviewId) {
+    return manageResponse(res, {
+      statusCode: status.BAD_REQUEST,
+      success: false,
+      message: 'User ID and Review ID are required',
+    });
+  }
+
+  const result = await reviewService.deleteReview(
+    reviewId as string,
+    userId as string,
+  );
+
+  manageResponse(res, {
+    statusCode: status.OK,
+    success: true,
+    message: 'Review deleted successfully (soft delete)',
+    data: null,
+  });
+});
 export const reviewController = {
   createReview,
+  updateReview,
+  deleteReview,
 };

--- a/src/app/modules/Review/review.controller.ts
+++ b/src/app/modules/Review/review.controller.ts
@@ -3,6 +3,34 @@ import catchAsyncResponse from '../../utils/catchAsync';
 import manageResponse from '../../utils/manageRes';
 import { reviewService } from './review.service';
 
+const getReview = catchAsyncResponse(async (req, res) => {
+  const result = await reviewService.getReview();
+  manageResponse(res, {
+    statusCode: status.OK,
+    success: true,
+    message: 'Reviews fetched successfully',
+    data: result,
+  });
+});
+const getSingleReview = catchAsyncResponse(async (req, res) => {
+  const result = await reviewService.getSingleReview(req.params.id);
+  manageResponse(res, {
+    statusCode: status.OK,
+    success: true,
+    message: 'Review fetched successfully',
+    data: result,
+  });
+});
+const getReviewByUserId = catchAsyncResponse(async (req, res) => {
+  const result = await reviewService.getReviewByUserId(req.params.userId);
+  manageResponse(res, {
+    statusCode: status.OK,
+    success: true,
+    message: 'Reviews fetched successfully by user ID',
+    data: result,
+  });
+});
+
 const createReview = catchAsyncResponse(async (req, res) => {
   const result = await reviewService.createReview(req.body);
   manageResponse(res, {
@@ -63,4 +91,7 @@ export const reviewController = {
   createReview,
   updateReview,
   deleteReview,
+  getReview,
+  getSingleReview,
+  getReviewByUserId,
 };

--- a/src/app/modules/Review/review.route.ts
+++ b/src/app/modules/Review/review.route.ts
@@ -2,12 +2,15 @@ import { Router } from 'express';
 import { reviewController } from './review.controller';
 import RequestValidator from '../../middlewares/requestValidator';
 import { reviewValidation } from './review.validation';
+import auth from '../../middlewares/auth';
+import { Role } from '@prisma/client';
 
 const router = Router();
 
 router.post(
   '/create-review',
   RequestValidator(reviewValidation.createReview),
+  auth(Role.ADMIN, Role.USER),
   reviewController.createReview,
 );
 

--- a/src/app/modules/Review/review.route.ts
+++ b/src/app/modules/Review/review.route.ts
@@ -6,7 +6,17 @@ import auth from '../../middlewares/auth';
 import { Role } from '@prisma/client';
 
 const router = Router();
-
+router.get('/', auth(Role.ADMIN, Role.USER), reviewController.getReview);
+router.get(
+  '/:id',
+  auth(Role.ADMIN, Role.USER),
+  reviewController.getSingleReview,
+);
+router.get(
+  '/user/:userId',
+  auth(Role.ADMIN, Role.USER),
+  reviewController.getReviewByUserId,
+);
 router.post(
   '/create-review',
   RequestValidator(reviewValidation.createReview),

--- a/src/app/modules/Review/review.route.ts
+++ b/src/app/modules/Review/review.route.ts
@@ -13,5 +13,16 @@ router.post(
   auth(Role.ADMIN, Role.USER),
   reviewController.createReview,
 );
+router.patch(
+  '/update-review',
+  RequestValidator(reviewValidation.updateReview),
+  auth(Role.ADMIN, Role.USER),
+  reviewController.updateReview,
+);
+router.delete(
+  '/delete-review',
+  auth(Role.ADMIN, Role.USER),
+  reviewController.deleteReview,
+);
 
 export const reviewRouter = router;

--- a/src/app/modules/Review/review.service.ts
+++ b/src/app/modules/Review/review.service.ts
@@ -1,5 +1,7 @@
 import { Review } from '@prisma/client';
 import { prisma } from '../../utils/Prisma';
+import { AppError } from '../../utils/AppError';
+import status from 'http-status';
 
 const createReview = async (reviewData: Review) => {
   const result = await prisma.review.create({
@@ -7,6 +9,45 @@ const createReview = async (reviewData: Review) => {
   });
   return result;
 };
+const updateReview = async (
+  updatedData: Partial<Review>,
+  reviewId: string,
+  userId: string,
+) => {
+  const existing = await prisma.review.findUniqueOrThrow({
+    where: { id: reviewId, isDeleted: false },
+  });
+  if (!existing || existing.userId !== userId) {
+    throw new AppError('Unauthorized or review not found', status.UNAUTHORIZED);
+  }
+  const result = await prisma.review.update({
+    where: { id: reviewId },
+    data: updatedData,
+  });
+  return result;
+};
+const deleteReview = async (reviewId: string, userId: string) => {
+  const existing = await prisma.review.findUniqueOrThrow({
+    where: { id: reviewId, isDeleted: false },
+  });
+
+  if (existing?.userId !== userId) {
+    throw new AppError(
+      'Unauthorized to delete this review',
+      status.UNAUTHORIZED,
+    );
+  }
+
+  const result = await prisma.review.update({
+    where: { id: reviewId },
+    data: { isDeleted: true },
+  });
+
+  return result;
+};
+
 export const reviewService = {
   createReview,
+  updateReview,
+  deleteReview,
 };

--- a/src/app/modules/Review/review.service.ts
+++ b/src/app/modules/Review/review.service.ts
@@ -3,6 +3,22 @@ import { prisma } from '../../utils/Prisma';
 import { AppError } from '../../utils/AppError';
 import status from 'http-status';
 
+const getReview = async () => {
+  const result = await prisma.review.findMany();
+  return result;
+};
+const getSingleReview = async (id: string) => {
+  const result = await prisma.review.findUniqueOrThrow({
+    where: { id: id },
+  });
+  return result;
+};
+const getReviewByUserId = async (id: string) => {
+  const result = await prisma.review.findMany({
+    where: { userId: id },
+  });
+  return result;
+};
 const createReview = async (reviewData: Review) => {
   const result = await prisma.review.create({
     data: reviewData,
@@ -50,4 +66,7 @@ export const reviewService = {
   createReview,
   updateReview,
   deleteReview,
+  getReview,
+  getSingleReview,
+  getReviewByUserId,
 };


### PR DESCRIPTION
feat: add review routes with authentication and authorization

What:
- Implemented multiple routes for reviews, including:
  - GET /: to retrieve all reviews (accessible by ADMIN and USER).
  - GET /:id: to retrieve a single review by its ID (accessible by ADMIN and USER).
  - GET /user/:userId: to retrieve reviews by a specific user (accessible by ADMIN and USER).
  - POST /create-review: to allow review creation (accessible by ADMIN and USER).
  - PATCH /update-review: to allow review updates (accessible by ADMIN and USER).
  - DELETE /delete-review: to allow review deletion (accessible by ADMIN and USER).
- Integrated `auth` middleware to check if the user is authorized to perform these actions based on their role (ADMIN or USER).
- Applied `RequestValidator` for input validation for creating and updating reviews using `reviewValidation.createReview` and `reviewValidation.updateReview`.

Why:
- To provide a set of API endpoints for creating, retrieving, updating, and deleting reviews.
- To enforce role-based access control ensuring only authorized users (ADMIN, USER) can perform these actions.
- To maintain the integrity of the review management system with proper validation and authentication.
